### PR TITLE
[MOBILE-1846] Upgrade and release airship-location-cordova plugin 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
-Version 11.0.0
-===============================
-- Initial release for use with Airship SDK 11+
+# airship-location-cordova Plugin Changelog
+
+## Version 12.0.0 - September 3, 2020
+
+Major release updating iOS and Android Location SDK versions to 13.5.4 and 13.3.2, respectively.
+
+## Version 11.1.0 - July 15, 2019
+
+Initial release for use with Airship SDK 11+
+
+## Version 11.0.0 - July 11, 2019
+
+Initial release for use with Airship SDK 11+
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airship-location-cordova",
-  "version": "11.1.0",
+  "version": "12.0.0",
   "description": "Cordova plugin to install the Airship location module",
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="airship-location-cordova"
-    version="11.1.0">
+    version="12.0.0">
 
     <name>Airship Location Plugin</name>
     <description>Cordova plugin to install the Airship Location module</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -73,7 +73,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="UrbanAirship-iOS-Location" spec="11.1.0" />
+                <pod name="Airship/Location" spec="13.5.4" />
             </pods>
         </podspec>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -46,6 +46,11 @@
         src="src/android/AirshipLocationPlugin.java"
         target-dir="src/com/urbanairship/cordova"/>
 
+        <framework
+            custom="true"
+            src="src/android/build-extras.gradle"
+            type="gradleReference"/>
+
     </platform>
 
     <!-- ios -->

--- a/src/android/AirshipLocationPlugin.java
+++ b/src/android/AirshipLocationPlugin.java
@@ -8,8 +8,8 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.AsyncTask;
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.v4.content.ContextCompat;
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 
 import com.urbanairship.UAirship;
 import com.urbanairship.util.HelperActivity;
@@ -97,12 +97,12 @@ public class AirshipLocationPlugin extends CordovaPlugin {
             RequestPermissionsTask task = new RequestPermissionsTask(context, new RequestPermissionsTask.Callback() {
                 @Override
                 public void onResult(boolean enabled) {
-                    UAirship.shared().getLocationManager().setLocationUpdatesEnabled(enabled);
+                    UAirship.shared().getLocationClient().setLocationUpdatesEnabled(enabled);
                 }
             });
             task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
         } else {
-            UAirship.shared().getLocationManager().setLocationUpdatesEnabled(enabled);
+            UAirship.shared().getLocationClient().setLocationUpdatesEnabled(enabled);
             callbackContext.success();
         }
     }
@@ -164,7 +164,7 @@ public class AirshipLocationPlugin extends CordovaPlugin {
      * @param callbackContext The callback context.
      */
     void isLocationEnabled(@NonNull JSONArray data, @NonNull CallbackContext callbackContext) {
-        int value = UAirship.shared().getLocationManager().isLocationUpdatesEnabled() ? 1 : 0;
+        int value = UAirship.shared().getLocationClient().isLocationUpdatesEnabled() ? 1 : 0;
         callbackContext.success(value);
     }
 
@@ -178,7 +178,7 @@ public class AirshipLocationPlugin extends CordovaPlugin {
      */
     void setBackgroundLocationEnabled(@NonNull JSONArray data, @NonNull CallbackContext callbackContext) throws JSONException {
         boolean enabled = data.getBoolean(0);
-        UAirship.shared().getLocationManager().setBackgroundLocationAllowed(enabled);
+        UAirship.shared().getLocationClient().setBackgroundLocationAllowed(enabled);
         callbackContext.success();
     }
 
@@ -189,7 +189,7 @@ public class AirshipLocationPlugin extends CordovaPlugin {
      * @param callbackContext The callback context.
      */
     void isBackgroundLocationEnabled(@NonNull JSONArray data, @NonNull CallbackContext callbackContext) {
-        int value = UAirship.shared().getLocationManager().isBackgroundLocationAllowed() ? 1 : 0;
+        int value = UAirship.shared().getLocationClient().isBackgroundLocationAllowed() ? 1 : 0;
         callbackContext.success(value);
     }
 }

--- a/src/android/AirshipLocationPlugin.java
+++ b/src/android/AirshipLocationPlugin.java
@@ -11,7 +11,7 @@ import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 
-import com.urbanairship.UAirship;
+import com.urbanairship.location.AirshipLocationManager;
 import com.urbanairship.util.HelperActivity;
 
 import org.apache.cordova.CallbackContext;
@@ -97,12 +97,12 @@ public class AirshipLocationPlugin extends CordovaPlugin {
             RequestPermissionsTask task = new RequestPermissionsTask(context, new RequestPermissionsTask.Callback() {
                 @Override
                 public void onResult(boolean enabled) {
-                    UAirship.shared().getLocationClient().setLocationUpdatesEnabled(enabled);
+                    AirshipLocationManager.shared().setLocationUpdatesEnabled(enabled);
                 }
             });
             task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
         } else {
-            UAirship.shared().getLocationClient().setLocationUpdatesEnabled(enabled);
+            AirshipLocationManager.shared().setLocationUpdatesEnabled(enabled);
             callbackContext.success();
         }
     }
@@ -117,7 +117,6 @@ public class AirshipLocationPlugin extends CordovaPlugin {
             return false;
         }
 
-        Context context = UAirship.getApplicationContext();
         return ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_DENIED &&
                 ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_DENIED;
     }
@@ -164,7 +163,7 @@ public class AirshipLocationPlugin extends CordovaPlugin {
      * @param callbackContext The callback context.
      */
     void isLocationEnabled(@NonNull JSONArray data, @NonNull CallbackContext callbackContext) {
-        int value = UAirship.shared().getLocationClient().isLocationUpdatesEnabled() ? 1 : 0;
+        int value = AirshipLocationManager.shared().isLocationUpdatesEnabled() ? 1 : 0;
         callbackContext.success(value);
     }
 
@@ -178,7 +177,7 @@ public class AirshipLocationPlugin extends CordovaPlugin {
      */
     void setBackgroundLocationEnabled(@NonNull JSONArray data, @NonNull CallbackContext callbackContext) throws JSONException {
         boolean enabled = data.getBoolean(0);
-        UAirship.shared().getLocationClient().setBackgroundLocationAllowed(enabled);
+        AirshipLocationManager.shared().setBackgroundLocationAllowed(enabled);
         callbackContext.success();
     }
 
@@ -189,7 +188,7 @@ public class AirshipLocationPlugin extends CordovaPlugin {
      * @param callbackContext The callback context.
      */
     void isBackgroundLocationEnabled(@NonNull JSONArray data, @NonNull CallbackContext callbackContext) {
-        int value = UAirship.shared().getLocationClient().isBackgroundLocationAllowed() ? 1 : 0;
+        int value = AirshipLocationManager.shared().isBackgroundLocationAllowed() ? 1 : 0;
         callbackContext.success(value);
     }
 }

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -6,8 +6,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.google.gms:google-services:4.3.3'
     }
 }
 
@@ -19,14 +19,13 @@ allprojects {
 }
 
 dependencies {
-    implementation 'com.android.support:support-v4:28.0.0'
-    implementation 'com.android.support:support-annotations:28.0.0'
-    implementation 'com.google.android.gms:play-services-location:16.0.0'
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.urbanairship.android:urbanairship-fcm:10.0.1'
+    api "androidx.core:core:1.3.0"
+    api "androidx.annotation:annotation:1.1.0"
+    implementation "com.google.android.gms:play-services-location:16.0.0"
+    implementation "com.urbanairship.android:urbanairship-location:13.3.2"
 }
 
-ext.cdvCompileSdkVersion = 28
+ext.cdvCompileSdkVersion = 29
 
 // For CI only. Verify our plugin is Java 6 compatible
 if (project.hasProperty('uaInternalJava6CompileOptions') && uaInternalJava6CompileOptions.toBoolean()) {


### PR DESCRIPTION
### What do these changes do?
Upgrade the iOS and Android Location SDKs to their newest versions.

### Why are these changes necessary?
SDKs were a couple of major versions behind, and there have been many changes. The plugin probably no longer worked with our current urbanairship-cordova plugin.

### How did you verify these changes?
Build and test in sample app

### Anything else a reviewer should know?
- The Android changes were straightforward.
- The iOS changes were bigger. The SDK code for enabling location updates now uses `UAApplicationState`, which has to be run on the main queue due to UI access. It might be possible to change the SDK to run just the UI access sections on the main queue, but dispatching to the main queue in the plugin works also.
