### PR TITLE
[MOBILE-1914] Update airship-location-cordova module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ Patch release updating iOS and Android Location SDK versions to 14.1.2 and 14.0.
 ### Changes
 - Xcode 12 is now required.
 - Requires Cordova iOS 6.1.0+, Cordova Android 9.0.0+.
-- Fixed conflict with play services with Cordova Android 9.0.0.
 
 ## Version 12.0.0 - September 3, 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # airship-location-cordova Plugin Changelog
 
+## Version 12.0.1 - September 30, 2020
+
+Patch release updating iOS and Android Location SDK versions to 14.1.2 and 14.0.1, respectively.
+
+### Changes
+- Xcode 12 is now required.
+- Requires Cordova iOS 6.1.0+, Cordova Android 9.0.0+.
+- Fixed conflict with play services with Cordova Android 9.0.0.
+
 ## Version 12.0.0 - September 3, 2020
 
 Major release updating iOS and Android Location SDK versions to 13.5.4 and 13.3.2, respectively.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Please visit http://support.urbanairship.com/ for any issues integrating or usin
 
 ### Requirements:
  - cordova >= 9.0.1
- - cordova-ios >= 5.0.1
+ - cordova-ios >= 6.1.0
+ - cordova-android >= 9.0.0
  - cococapods >= 1.7.3
  - urbanairship-cordova plugin  >= 8.0.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airship-location-cordova",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Cordova plugin to install the Airship location module",
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,10 +24,6 @@
 
     <!-- android -->
     <platform name="android">
-        <config-file target="config.xml" parent="/*">
-            <preference name="GradlePluginGoogleServicesEnabled" value="true" />
-            <preference name="GradlePluginGoogleServicesVersion" value="4.2.0" />
-        </config-file>
         <config-file parent="/widget" target="res/xml/config.xml">
             <feature name="AirshipLocation">
                 <param

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="airship-location-cordova"
-    version="12.0.0">
+    version="12.0.1">
 
     <name>Airship Location Plugin</name>
     <description>Cordova plugin to install the Airship Location module</description>
@@ -11,8 +11,8 @@
     <repo>https://github.com/urbanairship/airship-location-cordova</repo>
 
     <engines>
-        <engine name="cordova-android" version=">=4.1.0"/>
-        <engine name="cordova-ios" version=">=5.0.1"/>
+        <engine name="cordova-android" version=">=9.0.0"/>
+        <engine name="cordova-ios" version=">=6.1.0"/>
         <engine name="cordova" version=">=9.0.1"/>
     </engines>
 
@@ -24,7 +24,10 @@
 
     <!-- android -->
     <platform name="android">
-
+        <config-file target="config.xml" parent="/*">
+            <preference name="GradlePluginGoogleServicesEnabled" value="true" />
+            <preference name="GradlePluginGoogleServicesVersion" value="4.2.0" />
+        </config-file>
         <config-file parent="/widget" target="res/xml/config.xml">
             <feature name="AirshipLocation">
                 <param
@@ -70,10 +73,10 @@
         <!-- ios location framework -->
         <podspec>
             <config>
-                <source url="https://github.com/CocoaPods/Specs.git"/>
+                <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="Airship/Location" spec="13.5.4" />
+                <pod name="Airship/Location" spec="14.1.2" />
             </pods>
         </podspec>
 

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -1,16 +1,4 @@
 
-buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
-        classpath 'com.google.gms:google-services:4.3.3'
-    }
-}
-
 allprojects {
     repositories {
         google()
@@ -22,7 +10,7 @@ dependencies {
     api "androidx.core:core:1.3.0"
     api "androidx.annotation:annotation:1.1.0"
     implementation "com.google.android.gms:play-services-location:16.0.0"
-    implementation "com.urbanairship.android:urbanairship-location:13.3.2"
+    implementation "com.urbanairship.android:urbanairship-location:14.0.1"
 }
 
 ext.cdvCompileSdkVersion = 29
@@ -34,13 +22,5 @@ if (project.hasProperty('uaInternalJava6CompileOptions') && uaInternalJava6Compi
             sourceCompatibility JavaVersion.VERSION_1_6
             targetCompatibility JavaVersion.VERSION_1_6
         }
-    })
-}
-
-// Used to avoid conflicts with other plugins that also apply the GoogleServicesPlugin
-// See https://cordova.apache.org/docs/en/latest/guide/platforms/android/#setting-gradle-properties
-if (!project.hasProperty('uaSkipApplyGoogleServicesPlugin') || !uaSkipApplyGoogleServicesPlugin) {
-    cdvPluginPostBuildExtras.push({
-        apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
     })
 }


### PR DESCRIPTION
### What do these changes do?
Update airship location cordova module as a patch (12.0.1).
Then Android Location module to 14.0.1 and iOS Location module to 14.1.2.

### Why are these changes necessary?
To keep airship location cordova module up to date.

### How did you verify these changes?
Build and run Android and iOS. Check method AirshipLocation.setLocationEnabled works.
![2020-09-30](https://user-images.githubusercontent.com/24393953/94693314-d82d6080-0333-11eb-8610-6356b03bd1a5.jpeg)
![2020-09-30](https://user-images.githubusercontent.com/24393953/94693316-d95e8d80-0333-11eb-9d33-55aeda0372bb.jpg)

### Anything else a reviewer should know?
Also, I copied the fix for the conflict with play services from the cordova plugin.